### PR TITLE
Windows workaround for creation of files by template in ansible roles

### DIFF
--- a/django/tasks/10-preperation/10-workaround_requirements.yml
+++ b/django/tasks/10-preperation/10-workaround_requirements.yml
@@ -1,0 +1,18 @@
+---
+# Create directories for fileoutputs of the ansible "template" command, since there is a bug on windows host
+# systems, when files are created via "template" and the destination of these files is set to the vagrant 
+# shared path (or a subpath). 
+# Because of that files, created by the template command, should have one of the paths below as destination.
+# These files should afterwards be moved to their real destination, by using the shell command "mv".
+
+- name: create temp directory for generating settings
+  command: >
+    mkdir -p /etc/ansible/.vagrant_tmp/settings
+    
+- name: create temp directory for generating configurations
+  command: >
+    mkdir -p /etc/ansible/.vagrant_tmp/configuration
+
+- name: change permissions of temp directories
+  command: >
+    chmod 777 -R /etc/ansible/.vagrant_tmp

--- a/django/tasks/10-preperation/main.yml
+++ b/django/tasks/10-preperation/main.yml
@@ -1,0 +1,6 @@
+---
+# prepare workarounds which are needed (mainly for starting vagrant and provisionining from a windows host system)
+
+- include: 10-workaround_requirements.yml
+  tags: workaround_requirements
+  become_user: "root"

--- a/django/tasks/20-django/30-update_settings.yml
+++ b/django/tasks/20-django/30-update_settings.yml
@@ -10,25 +10,44 @@
     db_engine="{{ db_engine_postgis }}"
   when: enable_postgis
 
+  
+# there is a bug on windows host systems which doesn't allow to set the destionation for files,
+# created by the "template" command, to the shared path of vagrant. Instead of that, they are now
+# stored to a regular path within the box and in the next step moved by the shell command "mv" to 
+# their real destination.
 - name: configure django secret settings
   template: >
     src="secret.py.j2"
-    dest="{{ install_path }}/{{ service_name }}/{{ secret_settings }}"
+    dest="/etc/ansible/.vagrant_tmp/{{ secret_settings }}"
+    owner={{ service_user }}
+    group={{ service_group }}
+    mode=0644
+  notify:
+    - restart service group
+    
+- name: move secret settings to settings directory
+  command: >
+    mv /etc/ansible/.vagrant_tmp/{{ secret_settings }} {{ install_path }}/{{ service_name }}/{{ secret_settings }}
+  
+
+# there is a bug on windows host systems which doesn't allow to set the destionation for files,
+# created by the "template" command, to the shared path of vagrant. Instead of that, they are now
+# stored to a regular path within the box and in the next step moved by the shell command "mv" to 
+# their real destination.
+- name: configure django local settings
+  template: >
+    src="local.py.j2"
+    dest="/etc/ansible/.vagrant_tmp/{{ local_settings }}"
     owner={{ service_user }}
     group={{ service_group }}
     mode=0644
   notify:
     - restart service group
 
-- name: configure django local settings
-  template: >
-    src="local.py.j2"
-    dest="{{ install_path }}/{{ service_name }}/{{ local_settings }}"
-    owner={{ service_user }}
-    group={{ service_group }}
-    mode=0644
-  notify:
-    - restart service group
+- name: move local settings to settings directory
+  command: >
+    mv /etc/ansible/.vagrant_tmp/{{ local_settings }} {{ install_path }}/{{ service_name }}/{{ local_settings }}
+      
 
 - name: add DJANGO_SETTINGS_MODULE to .bashrc
   lineinfile: >

--- a/django/tasks/50-server/20-gunicorn.yml
+++ b/django/tasks/50-server/20-gunicorn.yml
@@ -4,14 +4,25 @@
 - name: install gunicorn
   pip: virtualenv="{{ virtualenv_path }}"
        name=gunicorn
+       
 
+# there is a bug on windows host systems which doesn't allow to set the destionation for files,
+# created by the "template" command, to the shared path of vagrant. Instead of that, they are now
+# stored to a regular path within the box and in the next step moved by the shell command "mv" to 
+# their real destination.
 - name: configure gunicorn
   template: >
     src="gunicorn.py.j2"
-    dest="{{ install_path }}/gunicorn.py"
+    dest="/etc/ansible/.vagrant_tmp/configuration/gunicorn.py"
     owner={{ service_user }}
     group={{ service_group }}
     mode=0644
     backup=yes
   notify:
     - restart django app
+
+- name: move configuration to install path
+  command: >
+    mv /etc/ansible/.vagrant_tmp/configuration/gunicorn.py {{ install_path }}/gunicorn.py
+    
+

--- a/django/tasks/50-server/21-uwsgi.yml
+++ b/django/tasks/50-server/21-uwsgi.yml
@@ -5,13 +5,22 @@
   pip: virtualenv="{{ virtualenv_path }}"
        name=uwsgi
 
+       
+# there is a bug on windows host systems which doesn't allow to set the destionation for files,
+# created by the "template" command, to the shared path of vagrant. Instead of that, they are now
+# stored to a regular path within the box and in the next step moved by the shell command "mv" to 
+# their real destination.
 - name: configure uwsgi
   template: >
     src="uwsgi.ini.j2"
-    dest="{{ install_path }}/uwsgi.ini"
+    dest="/etc/ansible/.vagrant_tmp/configuration/uwsgi.ini"
     owner={{ service_user }}
     group={{ service_group }}
     mode=0644
     backup=yes
   notify:
     - restart django app
+
+- name: move configuration to install path
+  command: >
+    mv /etc/ansible/.vagrant_tmp/configuration/uwsgi.ini{{ install_path }}/uwsgi.ini

--- a/django/tasks/80-terminate/10-remove_workaround_requirements.yml
+++ b/django/tasks/80-terminate/10-remove_workaround_requirements.yml
@@ -1,0 +1,7 @@
+---
+# do cleanup operations
+
+- name: remove temp directory for generating settings
+  command: >
+    rm -r /etc/ansible/.vagrant_tmp/   
+    

--- a/django/tasks/80-terminate/main.yml
+++ b/django/tasks/80-terminate/main.yml
@@ -1,0 +1,6 @@
+---
+# prepare workarounds which are needed (mainly for starting vagrant and provisionining from a windows host system)
+
+- include: 10-remove_workaround_requirements.yml
+  tags: remove_workaround_requirements
+  become_user: "root"

--- a/django/tasks/main.yml
+++ b/django/tasks/main.yml
@@ -14,9 +14,12 @@
     msg='Error: uWSGI with Apache is not supported!'
   when: use_apache|bool and use_uwsgi|bool
 
+- include: 10-preperation/main.yml
 - include: 20-django/main.yml
 
 - include: 50-server/main.yml
+
+- include: 80-terminate/main.yml
 
 - include: 90-commands/main.yml
   when: not disabled_by_default


### PR DESCRIPTION
In django\tasks\ two new folders have been added:
10-preparation and 80-terminate.

The first folder includes a task, which creates temp directories for the use of the template command.
The other folder deletes these directories after everything is done.

These temp directories are now used for template creation in:
20-django/30-update_settings.yml (2 times)
50-server/20-gunicorn.yml (1 time)
50-server/21-uwsgi.yml (1 time)

How these directories are used: 
The "dest" when creating files from templates is now not anymore the shared vagrant path (because this caused problems if the host system is Windows) but is now one of these new created temp directories.
After a file from a template has been created (now located in one of the temp directories) an additional command is executed, which moves the file from the temp directory to it's originally intended destination (this is done by using the standard shell command mv).
